### PR TITLE
feat: add two new methods showing the impact of allowing binary PyYAML

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,6 +12,10 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      - PyYAML
 config:
   options:
     debug:
@@ -43,6 +47,8 @@ actions:
         enum:
         - ops
         - relation-set
+        - slow-ops
+        - fast-ops
         default: ops
     required:
       - size

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,6 +91,18 @@ class CharmRelationTestCharm(ops.CharmBase):
         if method == "ops":
             tstart = time.time()
             rel.data[self.unit][key] = data
+        elif method == "slow-ops":
+            import yaml, ops._private.yaml
+            ops._private.yaml._safe_dumper = yaml.SafeDumper
+            ops._private.yaml._safe_loader = yaml.SafeLoader
+            tstart = time.time()
+            rel.data[self.unit][key] = data
+        elif method == "fast-ops":
+            import yaml, ops._private.yaml
+            ops._private.yaml._safe_dumper = yaml.CSafeDumper
+            ops._private.yaml._safe_loader = yaml.CSafeLoader
+            tstart = time.time()
+            rel.data[self.unit][key] = data
         elif method == "relation-set":
             file = tempfile.NamedTemporaryFile("w", delete=False)
             file.write(json.dumps({key: data}))


### PR DESCRIPTION
Adds two new methods: `fast-ops` and `slow-ops`, which are like the `ops` method, but force using the Python PyYAML (slow) or libyaml PyYAML (fast) versions of load/dump.

Also adjusts the build so that the binary PyYAML gets installed, so that the libyaml version is available. Note that this changes the "ops" method to be the same as "fast-ops" rather than "slow-ops" as previously.